### PR TITLE
Se corrigió el problema del tab en el login

### DIFF
--- a/wp-content/plugins/globalsax-core/globalsax-plugin-base.php
+++ b/wp-content/plugins/globalsax-core/globalsax-plugin-base.php
@@ -67,9 +67,10 @@ class GLOBALSAX_Plugin_Base {
     public function globalsax_add_JS() {
         wp_enqueue_script('jquery');
 
-        wp_register_script('globalsax-gs-tabNavigator', plugins_url('/js/gs_tabNavigator.js', __FILE__), array('jquery'), '1.0', true);
-        wp_enqueue_script('globalsax-gs-tabNavigator');
-
+        if (is_page('catalogo')){
+            wp_register_script('globalsax-gs-tabNavigator', plugins_url('/js/gs_tabNavigator.js', __FILE__), array('jquery'), '1.0', true);
+            wp_enqueue_script('globalsax-gs-tabNavigator');
+        }
         wp_register_script('globalsax-script', plugins_url('/js/globalsax-script.js', __FILE__), array('jquery'), '1.0', true);
         wp_enqueue_script('globalsax-script');
 


### PR DESCRIPTION
Este pr corrige lo siguiente:
1- El archivo tabNavigator.js se cargaba por defecto en todo el sitio. 
2- Este archivo sobreescribe la funcionalidad por defecto del tab y es específico para el catálogo.
3- Esto hace que no se pueda tabear en otros lugares del sitio porque queda sobreescrita la funcionalidad por defecto. Un ejemplo era en la página del login

Ahora se carga solo bajo la página catálogo. 